### PR TITLE
feat(orch/langgraph): scaffold LangGraph runtime and prefer when available

### DIFF
--- a/app/orch/langgraph_graph.py
+++ b/app/orch/langgraph_graph.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""
+LangGraph node scaffolding (safe fallback).
+
+If `langgraph` is available at runtime, this module provides a thin runtime
+wrapper that mimics a node-based execution. For now, nodes delegate to the
+existing Orchestrator logic to keep behavior identical while we land the
+interfaces and tests. This allows us to switch to real LangGraph nodes later
+without breaking callers.
+"""
+
+from typing import Any, Dict
+
+try:
+    import langgraph  # type: ignore  # noqa: F401
+    _HAS_LANGGRAPH = True
+except Exception:
+    _HAS_LANGGRAPH = False
+
+from .graph import Orchestrator as _FallbackOrchestrator
+from .checkpoint import MemoryCheckpointer
+
+
+class LangGraphRuntime:
+    """Node-style orchestrator façade.
+
+    For now it forwards to the fallback Orchestrator while we shape the API.
+    """
+
+    def __init__(self) -> None:
+        self._fb = _FallbackOrchestrator(MemoryCheckpointer())
+
+    def run(self, thread_id: str, instruction: str, simulate_interrupt: bool = False) -> Dict[str, Any]:
+        return self._fb.run(thread_id, instruction, simulate_interrupt=simulate_interrupt)
+
+    def resume(self, thread_id: str) -> Dict[str, Any]:
+        return self._fb.resume(thread_id)
+

--- a/app/orch/langgraph_impl.py
+++ b/app/orch/langgraph_impl.py
@@ -11,6 +11,7 @@ except Exception:
 
 from .graph import Orchestrator as _FallbackOrchestrator
 from .checkpoint import MemoryCheckpointer
+from .langgraph_graph import LangGraphRuntime
 
 
 class LangGraphOrchestrator:
@@ -21,10 +22,13 @@ class LangGraphOrchestrator:
     """
 
     def __init__(self):
+        # Prefer LangGraph runtime if available; otherwise fallback
         if _HAS_LANGGRAPH:
-            # Here we would wire actual LangGraph nodes and checkpointer.
-            # For now, use fallback orchestrator to keep behavior consistent.
-            pass
+            try:
+                self._fb = LangGraphRuntime()
+                return
+            except Exception:
+                pass
         self._fb = _FallbackOrchestrator(MemoryCheckpointer())
 
     def run(self, thread_id: str, instruction: str, simulate_interrupt: bool = False) -> Dict[str, Any]:
@@ -32,4 +36,3 @@ class LangGraphOrchestrator:
 
     def resume(self, thread_id: str) -> Dict[str, Any]:
         return self._fb.resume(thread_id)
-

--- a/docs/planner-navigator.md
+++ b/docs/planner-navigator.md
@@ -28,6 +28,11 @@ This document describes the Phase 8 loop: Plan → Navigate → Verify with inte
   1) Local-only trial: `pip install langgraph==<stable>` and run `pytest -k langgraph_orchestrator`.
   2) CI rollout: pin the version in `requirements.txt` and enable related tests in CI.
 
+### Current State (Scaffolding)
+
+- `app/orch/langgraph_graph.LangGraphRuntime` forwards to the existing Orchestrator while the node graph is stabilized.
+- This allows us to merge APIs and tests early; later we can flip the internals to real graph nodes without changing callers.
+
 ## Metrics
 
 - planning_runs_24h, navigator_avg_batch, page_change_interrupts_24h,


### PR DESCRIPTION
Adds LangGraphRuntime façade that forwards to existing Orchestrator for now; keeps APIs stable and enables optional tests. Docs updated with migration path.